### PR TITLE
Add env config for Stripe sync script

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+SUPABASE_URL=your-supabase-project-url
+SUPABASE_SERVICE_ROLE_KEY=service-key
+STRIPE_SECRET_KEY=stripe-secret-key

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ node_modules
 dist
 dist-ssr
 *.local
+.env
 
 # Editor directories and files
 .vscode/*

--- a/README.md
+++ b/README.md
@@ -71,3 +71,14 @@ Yes, you can!
 To connect a domain, navigate to Project > Settings > Domains and click Connect Domain.
 
 Read more here: [Setting up a custom domain](https://docs.lovable.dev/tips-tricks/custom-domain#step-by-step-guide)
+
+## Syncing Stripe products
+
+To sync products between Supabase and Stripe:
+
+1. Copy `.env.example` to `.env`.
+2. Fill in the following values in `.env`:
+   - `SUPABASE_URL=your-supabase-project-url`
+   - `SUPABASE_SERVICE_ROLE_KEY=service-key`
+   - `STRIPE_SECRET_KEY=stripe-secret-key`
+3. Run `npm run sync:stripe` to perform the synchronization.

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,7 @@
         "clsx": "^2.1.1",
         "cmdk": "^1.0.0",
         "date-fns": "^3.6.0",
+        "dotenv": "^17.2.1",
         "embla-carousel-react": "^8.3.0",
         "input-otp": "^1.2.4",
         "lucide-react": "^0.462.0",
@@ -4429,6 +4430,18 @@
       "dependencies": {
         "@babel/runtime": "^7.8.7",
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.2.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.1.tgz",
+      "integrity": "sha512-kQhDYKZecqnM0fCnzI5eIv5L4cAe/iRI+HqMbO/hbRdTAeXDG+M9FjipUxNfbARuEg4iHIbhnhs78BCHNbSxEQ==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "clsx": "^2.1.1",
     "cmdk": "^1.0.0",
     "date-fns": "^3.6.0",
+    "dotenv": "^17.2.1",
     "embla-carousel-react": "^8.3.0",
     "input-otp": "^1.2.4",
     "lucide-react": "^0.462.0",

--- a/scripts/sync-stripe-products.mjs
+++ b/scripts/sync-stripe-products.mjs
@@ -1,5 +1,8 @@
+import dotenv from 'dotenv';
 import Stripe from 'stripe';
 import { createClient } from '@supabase/supabase-js';
+
+dotenv.config();
 
 const stripeSecret = process.env.STRIPE_SECRET_KEY;
 const supabaseUrl = process.env.SUPABASE_URL;


### PR DESCRIPTION
## Summary
- load `.env` values in Stripe sync script
- provide `.env.example` and README instructions
- add dotenv dependency and ignore `.env`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688fa752bed8832aa4c3509b1685ed41