### PR TITLE
fix: handle missing origin in checkout

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
 SUPABASE_URL=your-supabase-project-url
 SUPABASE_SERVICE_ROLE_KEY=service-key
 STRIPE_SECRET_KEY=stripe-secret-key
+SITE_URL=http://localhost:5173


### PR DESCRIPTION
## Summary
- ensure create-payment function handles missing Authorization header
- use SITE_URL env fallback when Origin header is absent to build Stripe redirect URLs

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688fb3bd9da0832a91fa8a02fd83c766