### PR TITLE
fix: handle missing origin in checkout

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
 SUPABASE_URL=your-supabase-project-url
 SUPABASE_SERVICE_ROLE_KEY=service-key
 STRIPE_SECRET_KEY=stripe-secret-key
+SITE_URL=http://localhost:5173

--- a/src/hooks/useCart.ts
+++ b/src/hooks/useCart.ts
@@ -205,17 +205,10 @@ export function useCart() {
         return;
       }
 
-      if (cartItems.some(item => !item.stripe_price_id)) {
-        toast({
-          title: "Unavailable",
-          description: "Some items are not ready for checkout.",
-          variant: "destructive"
-        });
-        return;
-      }
-
       const payload = cartItems.map(item => ({
-        stripe_price_id: item.stripe_price_id!,
+        stripe_price_id: item.stripe_price_id,
+        price: item.price,
+        product_name: item.product_name,
         quantity: item.quantity,
       }));
 


### PR DESCRIPTION
## Summary
- ensure create-payment function handles missing Authorization header
- use SITE_URL env fallback when Origin header is absent to build Stripe redirect URLs
- fall back to inline price data when Stripe price IDs are missing or invalid

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688fb3bd9da0832a91fa8a02fd83c766