### PR TITLE
feat: tune button highlights for context

### DIFF
--- a/src/components/CartModal.tsx
+++ b/src/components/CartModal.tsx
@@ -119,7 +119,7 @@ export function CartModal({ isOpen, onClose }: CartModalProps) {
                     <Button
                       variant="ghost"
                       size="icon"
-                      className="h-8 w-8 text-destructive hover:text-destructive"
+                      className="h-8 w-8 text-destructive hover:text-destructive hover:bg-destructive/10 focus-visible:ring-destructive"
                       onClick={() => removeItem(item.id)}
                     >
                       <X className="h-3 w-3" />
@@ -143,7 +143,11 @@ export function CartModal({ isOpen, onClose }: CartModalProps) {
             <Separator />
 
             <div className="flex gap-2">
-              <Button variant="outline" onClick={clearCart} className="flex-1">
+              <Button
+                variant="outline"
+                onClick={clearCart}
+                className="flex-1 text-destructive hover:bg-destructive/10 focus-visible:ring-destructive"
+              >
                 Clear Cart
               </Button>
               <Button onClick={handleCheckout} className="flex-1">

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -5,19 +5,22 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
   {
     variants: {
       variant: {
-        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        default:
+          "bg-primary text-primary-foreground hover:bg-primary/90 focus-visible:ring-primary",
         destructive:
-          "bg-destructive text-destructive-foreground hover:bg-destructive/90",
+          "bg-destructive text-destructive-foreground hover:bg-destructive/90 focus-visible:ring-destructive",
         outline:
-          "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+          "border border-input bg-background hover:bg-accent hover:text-accent-foreground focus-visible:ring-accent",
         secondary:
-          "bg-secondary text-secondary-foreground hover:bg-secondary/80",
-        ghost: "hover:bg-accent hover:text-accent-foreground",
-        link: "text-primary underline-offset-4 hover:underline",
+          "bg-secondary text-secondary-foreground hover:bg-secondary/80 focus-visible:ring-secondary",
+        ghost:
+          "hover:bg-accent hover:text-accent-foreground focus-visible:ring-accent",
+        link:
+          "text-primary underline-offset-4 hover:underline focus-visible:ring-primary",
       },
       size: {
         default: "h-10 px-4 py-2",


### PR DESCRIPTION
## Summary
- refine Button component to use variant-specific focus ring colors
- highlight cart deletion actions with destructive red accents

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6890652918bc832b8703c68691cdacd3